### PR TITLE
Implement MTGA collection tracker core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+.venv/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,47 @@
-# MTGAcollection
+# MTGA Collection Tracker
+
+A headless Magic: The Gathering Arena collection tracker for macOS that tails the
+Arena `Player.log`, persists the card collection to SQLite, and exports the
+current collection to CSV/JSON files that can be consumed by spreadsheets or
+other tooling.  The tracker is intentionally lightweight and designed to run as
+a background service started via `launchd`.
+
+## Features
+
+- Poll-based file tailer with log-rotation detection
+- Snapshot and delta log parsing resilient to key casing differences
+- Durable SQLite store for the collection, metadata, and pending deltas
+- Automatic Scryfall metadata import with caching
+- Atomic CSV/JSON exports located under `~/Documents/MTGA`
+- Minimal scheduler for periodic tasks such as mapping refreshes
+
+## Repository layout
+
+```
+mtga-collection-tracker/
+  launchd/                         # launchd agent definition
+  scripts/                         # helper scripts for installation
+  src/                             # tracker implementation
+  tests/                           # pytest based test-suite
+```
+
+## Development
+
+The project targets Python 3.11.  Create a virtual environment and install
+`pytest` when hacking on the codebase:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements-dev.txt  # optional helper if you create one
+pytest
+```
+
+Running the tracker in the foreground is useful when developing locally:
+
+```bash
+python -m src.tracker run --once
+```
+
+The helper scripts under `scripts/` illustrate how to install the tracker as a
+`launchd` agent on macOS.

--- a/launchd/com.navid.mtga.collection.tracker.plist
+++ b/launchd/com.navid.mtga.collection.tracker.plist
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.navid.mtga.collection.tracker</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>@PYTHON@</string>
+    <string>@TRACKER_SCRIPT@</string>
+    <string>run</string>
+  </array>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>StandardOutPath</key>
+  <string>@LOG_DIR@/agent.log</string>
+  <key>StandardErrorPath</key>
+  <string>@LOG_DIR@/agent.log</string>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PYTHONUNBUFFERED</key>
+    <string>1</string>
+  </dict>
+</dict>
+</plist>

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd)"
+BASE_DIR="${MTGA_TRACKER_BASE_DIR:-$HOME}"
+SUPPORT_DIR="$BASE_DIR/Library/Application Support/mtga-collection-tracker"
+LOG_DIR="$BASE_DIR/Library/Logs/mtga-collection-tracker"
+EXPORT_DIR="$BASE_DIR/Documents/MTGA"
+VENV_DIR="$SUPPORT_DIR/venv"
+PYTHON_BIN="${PYTHON_BIN:-python3}"
+PLIST_DEST="$HOME/Library/LaunchAgents/com.navid.mtga.collection.tracker.plist"
+
+mkdir -p "$SUPPORT_DIR" "$LOG_DIR" "$EXPORT_DIR" "$(dirname "$PLIST_DEST")"
+
+if [ ! -d "$VENV_DIR" ]; then
+  "$PYTHON_BIN" -m venv "$VENV_DIR"
+fi
+"$VENV_DIR/bin/pip" install --upgrade pip >/dev/null
+"$VENV_DIR/bin/pip" install --upgrade requests orjson >/dev/null
+
+cat "$SCRIPT_DIR/launchd/com.navid.mtga.collection.tracker.plist" \
+  | sed "s|@PYTHON@|$VENV_DIR/bin/python|" \
+  | sed "s|@TRACKER_SCRIPT@|$SCRIPT_DIR/src/tracker.py|" \
+  | sed "s|@LOG_DIR@|$LOG_DIR|" >"$PLIST_DEST"
+
+if command -v launchctl >/dev/null 2>&1; then
+  launchctl unload -w "$PLIST_DEST" >/dev/null 2>&1 || true
+  launchctl load -w "$PLIST_DEST"
+else
+  echo "launchctl not available; skipping agent load" >&2
+fi
+
+"$VENV_DIR/bin/python" "$SCRIPT_DIR/src/tracker.py" run --once
+"$VENV_DIR/bin/python" "$SCRIPT_DIR/src/tracker.py" status

--- a/scripts/run_once.sh
+++ b/scripts/run_once.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd)"
+PYTHON_BIN="${PYTHON_BIN:-python3}"
+BASE_DIR="${MTGA_TRACKER_BASE_DIR:-}" 
+
+if [ -n "$BASE_DIR" ]; then
+  MTGA_TRACKER_BASE_DIR="$BASE_DIR" "$PYTHON_BIN" "$SCRIPT_DIR/src/tracker.py" run --once
+else
+  "$PYTHON_BIN" "$SCRIPT_DIR/src/tracker.py" run --once
+fi

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_DIR="${MTGA_TRACKER_BASE_DIR:-$HOME}"
+SUPPORT_DIR="$BASE_DIR/Library/Application Support/mtga-collection-tracker"
+PLIST_DEST="$HOME/Library/LaunchAgents/com.navid.mtga.collection.tracker.plist"
+
+if command -v launchctl >/dev/null 2>&1 && [ -f "$PLIST_DEST" ]; then
+  launchctl unload -w "$PLIST_DEST" >/dev/null 2>&1 || true
+fi
+
+rm -f "$PLIST_DEST"
+rm -rf "$SUPPORT_DIR/venv"
+
+echo "State database and exports preserved in $SUPPORT_DIR"

--- a/src/config.py
+++ b/src/config.py
@@ -1,0 +1,140 @@
+"""Configuration helpers for mtga-collection-tracker."""
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+_DEFAULT_REFRESH_DAYS = 7
+_DEFAULT_ACTIVE_INTERVAL = 0.5
+_DEFAULT_IDLE_INTERVAL = 5.0
+
+
+@dataclass(frozen=True)
+class Paths:
+    """Convenience container for well known paths."""
+
+    base_dir: Path
+    support_dir: Path
+    log_dir: Path
+    documents_dir: Path
+    export_dir: Path
+    state_db: Path
+    config_file: Path
+    mapping_cache: Path
+    csv_export: Path
+    json_export: Path
+
+
+@dataclass
+class Config:
+    """Resolved configuration values for the tracker."""
+
+    paths: Paths
+    refresh_days: int = _DEFAULT_REFRESH_DAYS
+    active_interval: float = _DEFAULT_ACTIVE_INTERVAL
+    idle_interval: float = _DEFAULT_IDLE_INTERVAL
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "export_dir": str(self.paths.export_dir),
+            "refresh_days": self.refresh_days,
+            "active_interval": self.active_interval,
+            "idle_interval": self.idle_interval,
+        }
+
+
+def _expand(path: Path) -> Path:
+    return Path(os.path.expandvars(os.path.expanduser(str(path))))
+
+
+def determine_base_dir(explicit: Optional[Path] = None) -> Path:
+    """Return the base directory for all tracker files."""
+
+    if explicit is not None:
+        return _expand(explicit)
+    env = os.environ.get("MTGA_TRACKER_BASE_DIR")
+    if env:
+        return _expand(Path(env))
+    # The repository defaults to macOS style layout even on Linux for
+    # deterministic tests.  Tests override the base via the environment.
+    return Path.home()
+
+
+def build_paths(base_dir: Optional[Path] = None) -> Paths:
+    base = determine_base_dir(base_dir)
+    support_dir = base / "Library" / "Application Support" / "mtga-collection-tracker"
+    log_dir = base / "Library" / "Logs" / "mtga-collection-tracker"
+    documents_dir = base / "Documents" / "MTGA"
+    export_dir = documents_dir
+    state_db = support_dir / "state.db"
+    config_file = support_dir / "config.json"
+    mapping_cache = support_dir / "scryfall_default_cards.json"
+    csv_export = export_dir / "collection.csv"
+    json_export = export_dir / "collection.json"
+    return Paths(
+        base_dir=base,
+        support_dir=support_dir,
+        log_dir=log_dir,
+        documents_dir=documents_dir,
+        export_dir=export_dir,
+        state_db=state_db,
+        config_file=config_file,
+        mapping_cache=mapping_cache,
+        csv_export=csv_export,
+        json_export=json_export,
+    )
+
+
+def ensure_directories(paths: Paths) -> None:
+    """Create all required directories if they do not already exist."""
+
+    for path in (paths.support_dir, paths.log_dir, paths.export_dir):
+        path.mkdir(parents=True, exist_ok=True)
+
+
+def load_config(base_dir: Optional[Path] = None) -> Config:
+    """Load configuration from disk, creating defaults if needed."""
+
+    paths = build_paths(base_dir)
+    ensure_directories(paths)
+    refresh_days = _DEFAULT_REFRESH_DAYS
+    active_interval = _DEFAULT_ACTIVE_INTERVAL
+    idle_interval = _DEFAULT_IDLE_INTERVAL
+    if paths.config_file.exists():
+        try:
+            data = json.loads(paths.config_file.read_text())
+        except json.JSONDecodeError:
+            data = {}
+        refresh_days = int(data.get("refresh_days", refresh_days))
+        if "active_interval" in data:
+            active_interval = float(data["active_interval"])
+        if "idle_interval" in data:
+            idle_interval = float(data["idle_interval"])
+        export_dir = _expand(Path(data.get("export_dir", paths.export_dir)))
+        if export_dir != paths.export_dir:
+            paths = Paths(
+                base_dir=paths.base_dir,
+                support_dir=paths.support_dir,
+                log_dir=paths.log_dir,
+                documents_dir=paths.documents_dir,
+                export_dir=export_dir,
+                state_db=paths.state_db,
+                config_file=paths.config_file,
+                mapping_cache=paths.mapping_cache,
+                csv_export=export_dir / "collection.csv",
+                json_export=export_dir / "collection.json",
+            )
+            ensure_directories(paths)
+    else:
+        save_config(Config(paths=paths, refresh_days=refresh_days, active_interval=active_interval, idle_interval=idle_interval))
+    return Config(paths=paths, refresh_days=refresh_days, active_interval=active_interval, idle_interval=idle_interval)
+
+
+def save_config(config: Config) -> None:
+    config.paths.config_file.write_text(json.dumps(config.to_dict(), indent=2))
+
+
+__all__ = ["Config", "Paths", "build_paths", "determine_base_dir", "ensure_directories", "load_config", "save_config"]

--- a/src/exporter.py
+++ b/src/exporter.py
@@ -1,0 +1,63 @@
+"""CSV and JSON export helpers."""
+from __future__ import annotations
+
+import csv
+import json
+import os
+from typing import List, Sequence, Tuple
+
+from .config import Config
+from .store import Store
+
+Row = Tuple[int, int, str, str, str]
+
+
+class Exporter:
+    def __init__(self, config: Config, store: Store) -> None:
+        self.config = config
+        self.store = store
+
+    def export(self) -> int:
+        cards = self.store.get_all_cards()
+        metadata = self.store.get_metadata_map()
+        rows: List[Row] = []
+        for arena_id, quantity in cards.items():
+            name, set_code, rarity = metadata.get(arena_id, ("", "", ""))
+            rows.append((arena_id, quantity, name, set_code, rarity))
+        rows.sort(key=lambda row: (row[2].lower(), row[3].lower(), row[0]))
+        self._write_csv(rows)
+        self._write_json(rows)
+        return len(rows)
+
+    # ------------------------------------------------------------------
+
+    def _write_csv(self, rows: Sequence[Row]) -> None:
+        path = self.config.paths.csv_export
+        temp = path.with_suffix(path.suffix + ".tmp")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with temp.open("w", newline="", encoding="utf-8") as handle:
+            writer = csv.writer(handle)
+            writer.writerow(["arena_id", "quantity", "name", "set", "rarity"])
+            for row in rows:
+                writer.writerow(row)
+        os.replace(temp, path)
+
+    def _write_json(self, rows: Sequence[Row]) -> None:
+        path = self.config.paths.json_export
+        temp = path.with_suffix(path.suffix + ".tmp")
+        payload = [
+            {
+                "arena_id": arena_id,
+                "quantity": quantity,
+                "name": name,
+                "set": set_code,
+                "rarity": rarity,
+            }
+            for arena_id, quantity, name, set_code, rarity in rows
+        ]
+        path.parent.mkdir(parents=True, exist_ok=True)
+        temp.write_text(json.dumps(payload, indent=2))
+        os.replace(temp, path)
+
+
+__all__ = ["Exporter", "Row"]

--- a/src/jsonutil.py
+++ b/src/jsonutil.py
@@ -1,0 +1,24 @@
+"""Lightweight JSON helpers with optional orjson acceleration."""
+from __future__ import annotations
+
+from typing import Any
+
+try:  # pragma: no cover - optional dependency
+    import orjson  # type: ignore
+except ImportError:  # pragma: no cover - fallback path
+    import json
+
+    def loads(data: str) -> Any:
+        return json.loads(data)
+
+    def dumps(data: Any) -> str:
+        return json.dumps(data)
+else:  # pragma: no cover - executed when orjson is available
+    def loads(data: str) -> Any:
+        return orjson.loads(data)
+
+    def dumps(data: Any) -> str:
+        return orjson.dumps(data).decode("utf-8")
+
+
+__all__ = ["loads", "dumps"]

--- a/src/mapping.py
+++ b/src/mapping.py
@@ -1,0 +1,114 @@
+"""Scryfall mapping management."""
+from __future__ import annotations
+
+import datetime as _dt
+import json
+from typing import Dict, Iterable, Optional
+
+try:  # pragma: no cover - optional dependency
+    import requests
+except ImportError:  # pragma: no cover
+    requests = None  # type: ignore
+
+from .config import Config
+from .store import Store
+
+_DEFAULT_BULK_URL = "https://data.scryfall.io/default-cards/default-cards-20240101000000.json"
+_UTC = _dt.timezone.utc
+
+
+def _utcnow() -> _dt.datetime:
+    return _dt.datetime.now(tz=_UTC)
+
+
+class MappingManager:
+    """Download and persist Scryfall card metadata."""
+
+    def __init__(self, config: Config, store: Store) -> None:
+        self.config = config
+        self.store = store
+
+    # ------------------------------------------------------------------
+    # Public API
+
+    def needs_refresh(self, now: Optional[_dt.datetime] = None) -> bool:
+        last_refresh = self.store.get_state("mapping_refreshed_at")
+        if not last_refresh:
+            return True
+        try:
+            last_dt = _dt.datetime.fromisoformat(last_refresh)
+        except ValueError:
+            return True
+        now = now or _utcnow()
+        return (now - last_dt) >= _dt.timedelta(days=self.config.refresh_days)
+
+    def refresh(self, *, url: str = _DEFAULT_BULK_URL, now: Optional[_dt.datetime] = None) -> int:
+        data = self._download(url)
+        path = self.config.paths.mapping_cache
+        path.write_text(data)
+        mapping = json.loads(data)
+        timestamp = now or _utcnow()
+        count = self._write_mapping(mapping, now=timestamp)
+        self.store.set_state("mapping_refreshed_at", timestamp.isoformat())
+        return count
+
+    def update_from_cache(self, now: Optional[_dt.datetime] = None) -> int:
+        path = self.config.paths.mapping_cache
+        if not path.exists():
+            return 0
+        mapping = json.loads(path.read_text())
+        return self._write_mapping(mapping, now=now)
+
+    # ------------------------------------------------------------------
+    # internal helpers
+
+    def _download(self, url: str) -> str:
+        if requests is None:
+            from urllib.request import urlopen
+
+            with urlopen(url) as resp:  # type: ignore[call-arg]
+                return resp.read().decode("utf-8")
+        response = requests.get(url, timeout=30)
+        response.raise_for_status()
+        return response.text
+
+    def _write_mapping(self, mapping: Iterable[dict], now: Optional[_dt.datetime] = None) -> int:
+        chosen: Dict[int, dict] = {}
+        for card in mapping:
+            arena_id = card.get("arena_id")
+            if arena_id is None:
+                continue
+            arena_id = int(arena_id)
+            if arena_id in chosen and not self._prefer(card, chosen[arena_id]):
+                continue
+            chosen[arena_id] = card
+        timestamp = (now or _utcnow()).isoformat()
+        rows = [
+            (
+                arena_id,
+                str(card.get("name", "")),
+                str(card.get("set", "")),
+                str(card.get("rarity", "")),
+                timestamp,
+            )
+            for arena_id, card in chosen.items()
+        ]
+        if rows:
+            self.store.upsert_metadata(rows)
+        return len(rows)
+
+    def _prefer(self, new: dict, current: dict) -> bool:
+        # Avoid promo duplicates if a main set version exists.
+        new_set_type = str(new.get("set_type", ""))
+        cur_set_type = str(current.get("set_type", ""))
+        if cur_set_type == "promo" and new_set_type != "promo":
+            return True
+        if new_set_type == "promo" and cur_set_type != "promo":
+            return False
+        # Fallback to whichever entry was updated most recently.
+        new_released = str(new.get("released_at", ""))
+        cur_released = str(current.get("released_at", ""))
+        return new_released >= cur_released
+
+
+__all__ = ["MappingManager"]

--- a/src/parser.py
+++ b/src/parser.py
@@ -1,0 +1,228 @@
+"""Log parsing utilities for mtga-collection-tracker."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, Iterator, List, Optional, Tuple
+
+from . import jsonutil
+
+# Keys that usually indicate a full inventory snapshot.
+_SNAPSHOT_KEYS = {"cards", "ownedcards"}
+# Keys that indicate delta style payloads.
+_DELTA_EVENT_KEYS = {
+    "inventorydelta",
+    "inventoryupdated",
+    "boosteropened",
+    "eventreward",
+    "rewardgranted",
+    "dailywin",
+    "craftcard",
+    "upgradecard",
+    "vaultprogress",
+    "vaultreward",
+    "wildcardgranted",
+}
+_ID_KEYS = ("grpid", "grp_id", "titleid", "title_id", "arenaid", "cardid", "mtgaid")
+_SNAPSHOT_COUNT_KEYS = ("quantity", "qty", "count")
+_DELTA_COUNT_KEYS = ("delta", "quantitydelta", "change", "amount")
+
+
+@dataclass
+class SnapshotEvent:
+    cards: Dict[int, int]
+    source: str
+    raw: Dict[str, Any]
+
+
+@dataclass
+class DeltaEvent:
+    deltas: Dict[int, int]
+    source: str
+    raw: Dict[str, Any]
+
+
+class Parser:
+    """Extract JSON payloads from MTGA log lines."""
+
+    def __init__(self) -> None:
+        pass
+    # ------------------------------------------------------------------
+    # public API
+
+    def parse_line(self, line: str) -> List[Any]:
+        events: List[Any] = []
+        for snippet in self._extract_json_strings(line):
+            try:
+                data = jsonutil.loads(snippet)
+            except ValueError:
+                continue
+            events.extend(self._parse_json_object(data))
+        return events
+
+    # ------------------------------------------------------------------
+    # internal helpers
+
+    def _extract_json_strings(self, text: str) -> Iterator[str]:
+        depth = 0
+        start = None
+        for idx, char in enumerate(text):
+            if char == "{":
+                if depth == 0:
+                    start = idx
+                depth += 1
+            elif char == "}":
+                if depth == 0:
+                    continue
+                depth -= 1
+                if depth == 0 and start is not None:
+                    snippet = text[start : idx + 1]
+                    start = None
+                    yield snippet
+
+    def _parse_json_object(self, obj: Any) -> List[Any]:
+        if not isinstance(obj, dict):
+            return []
+        delta_events: List[DeltaEvent] = []
+        for source, deltas in self._extract_delta_events(obj):
+            if deltas:
+                delta_events.append(DeltaEvent(deltas=deltas, source=source, raw=obj))
+        if delta_events:
+            return delta_events
+        # Snapshots are rare but easy to detect: a dict containing a list under
+        # a key "Cards" or "OwnedCards" with absolute quantities.
+        snapshot_cards = self._extract_snapshot_cards(obj)
+        if snapshot_cards:
+            return [SnapshotEvent(snapshot_cards, source="snapshot", raw=obj)]
+        return []
+
+    # ------------------------------------------------------------------
+    # snapshot helpers
+
+    def _extract_snapshot_cards(self, obj: Dict[str, Any]) -> Dict[int, int]:
+        card_entries = self._find_card_entries(obj, keys=_SNAPSHOT_KEYS)
+        cards: Dict[int, int] = {}
+        for entry in card_entries:
+            arena_id = self._extract_arena_id(entry)
+            if arena_id is None:
+                continue
+            quantity = self._extract_first_int(entry, _SNAPSHOT_COUNT_KEYS)
+            if quantity is None:
+                continue
+            cards[arena_id] = max(int(quantity), 0)
+        return cards
+
+    # ------------------------------------------------------------------
+    # delta helpers
+
+    def _extract_delta_events(self, obj: Dict[str, Any]) -> Iterator[Tuple[str, Dict[int, int]]]:
+        for key, value in self._walk_dict(obj):
+            if key in _DELTA_EVENT_KEYS:
+                deltas = self._normalise_deltas(value)
+                if deltas:
+                    yield key, deltas
+
+    def _normalise_deltas(self, value: Any) -> Dict[int, int]:
+        deltas: Dict[int, int] = {}
+        entries = self._collect_card_like_entries(value)
+        for entry, multiplier in entries:
+            arena_id = self._extract_arena_id(entry)
+            if arena_id is None:
+                continue
+            delta = self._extract_first_int(entry, _DELTA_COUNT_KEYS)
+            if delta is not None:
+                change = int(delta) * multiplier
+            else:
+                quantity = self._extract_first_int(entry, _SNAPSHOT_COUNT_KEYS)
+                if quantity is None:
+                    continue
+                change = int(quantity) * multiplier
+            if change == 0:
+                continue
+            deltas[arena_id] = deltas.get(arena_id, 0) + change
+        return deltas
+
+    def _collect_card_like_entries(self, value: Any) -> List[Tuple[Dict[str, Any], int]]:
+        results: List[Tuple[Dict[str, Any], int]] = []
+        if isinstance(value, dict):
+            for key, inner in value.items():
+                lower = key.lower()
+                if lower in ("adds", "addedcards", "grantedcards"):
+                    results.extend([(item, 1) for item in self._ensure_list(inner)])
+                elif lower in ("removes", "removedcards", "spentcards"):
+                    results.extend([(item, -1) for item in self._ensure_list(inner)])
+                elif lower in ("changes", "cards", "deltas"):
+                    results.extend([(item, 1) for item in self._ensure_list(inner)])
+                else:
+                    results.extend(self._collect_card_like_entries(inner))
+        elif isinstance(value, list):
+            for item in value:
+                results.extend(self._collect_card_like_entries(item))
+        return [(entry, multiplier) for entry, multiplier in results if isinstance(entry, dict)]
+
+    # ------------------------------------------------------------------
+    # generic traversal helpers
+
+    def _find_card_entries(self, obj: Any, keys: Iterable[str]) -> List[Dict[str, Any]]:
+        results: List[Dict[str, Any]] = []
+        key_set = {k.lower() for k in keys}
+        if isinstance(obj, dict):
+            for key, value in obj.items():
+                lower = key.lower()
+                if lower in key_set:
+                    for item in self._ensure_list(value):
+                        if isinstance(item, dict):
+                            results.append(item)
+                else:
+                    results.extend(self._find_card_entries(value, keys))
+        elif isinstance(obj, list):
+            for item in obj:
+                results.extend(self._find_card_entries(item, keys))
+        return results
+
+    def _walk_dict(self, obj: Any) -> Iterator[Tuple[str, Any]]:
+        if isinstance(obj, dict):
+            for key, value in obj.items():
+                yield key.lower(), value
+                yield from self._walk_dict(value)
+        elif isinstance(obj, list):
+            for item in obj:
+                yield from self._walk_dict(item)
+
+    def _ensure_list(self, value: Any) -> List[Any]:
+        if isinstance(value, list):
+            return value
+        return [value]
+
+    def _extract_arena_id(self, entry: Dict[str, Any]) -> Optional[int]:
+        for key in _ID_KEYS:
+            if key in entry:
+                return int(entry[key])
+        for key, value in entry.items():
+            if isinstance(key, str) and key.lower() in _ID_KEYS:
+                return int(value)
+        # As a fallback, arena ID might be stored under the canonical key
+        # "id" when the payload only contains card information.
+        if "id" in entry:
+            try:
+                return int(entry["id"])
+            except (TypeError, ValueError):
+                return None
+        return None
+
+    def _extract_first_int(self, entry: Dict[str, Any], keys: Iterable[str]) -> Optional[int]:
+        for key in keys:
+            value = entry.get(key)
+            if value is None:
+                value = entry.get(key.capitalize())
+            if value is None:
+                value = entry.get(key.upper())
+            if value is None:
+                continue
+            try:
+                return int(value)
+            except (TypeError, ValueError):
+                continue
+        return None
+
+
+__all__ = ["Parser", "SnapshotEvent", "DeltaEvent"]

--- a/src/scheduler.py
+++ b/src/scheduler.py
@@ -1,0 +1,44 @@
+"""Very small periodic scheduler used by the tracker."""
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Callable, Dict, List, Optional
+
+
+@dataclass
+class _Task:
+    name: str
+    interval: float
+    callback: Callable[[], None]
+    last_run: float
+
+
+class Scheduler:
+    def __init__(self, *, time_fn: Callable[[], float] = time.monotonic) -> None:
+        self._time_fn = time_fn
+        self._tasks: Dict[str, _Task] = {}
+
+    def add_task(self, name: str, interval: float, callback: Callable[[], None]) -> None:
+        now = self._time_fn()
+        self._tasks[name] = _Task(name=name, interval=interval, callback=callback, last_run=now - interval)
+
+    def run_pending(self) -> List[str]:
+        now = self._time_fn()
+        executed: List[str] = []
+        for task in self._tasks.values():
+            if now - task.last_run >= task.interval:
+                task.callback()
+                task.last_run = now
+                executed.append(task.name)
+        return executed
+
+    def time_until_next_task(self) -> Optional[float]:
+        if not self._tasks:
+            return None
+        now = self._time_fn()
+        remaining = [max(task.interval - (now - task.last_run), 0.0) for task in self._tasks.values()]
+        return min(remaining)
+
+
+__all__ = ["Scheduler"]

--- a/src/store.py
+++ b/src/store.py
@@ -1,0 +1,171 @@
+"""SQLite persistence for mtga-collection-tracker."""
+from __future__ import annotations
+
+import sqlite3
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, Iterator, List, Optional, Tuple
+
+
+@dataclass
+class PendingDelta:
+    arena_id: int
+    delta: int
+    ts: str
+
+
+class Store:
+    """Lightweight wrapper around SQLite to keep tracker state durable."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = Path(path)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._lock = threading.Lock()
+        self._conn = sqlite3.connect(str(self.path), check_same_thread=False)
+        self._conn.row_factory = sqlite3.Row
+        self._init_schema()
+
+    def close(self) -> None:
+        self._conn.close()
+
+    # -- schema -----------------------------------------------------------------
+
+    def _init_schema(self) -> None:
+        with self._conn:  # autocommit transaction
+            self._conn.executescript(
+                """
+                CREATE TABLE IF NOT EXISTS cards(
+                    arena_id INTEGER PRIMARY KEY,
+                    quantity INTEGER NOT NULL
+                );
+                CREATE TABLE IF NOT EXISTS metadata(
+                    arena_id INTEGER PRIMARY KEY,
+                    name TEXT,
+                    set_code TEXT,
+                    rarity TEXT,
+                    updated_at TEXT
+                );
+                CREATE TABLE IF NOT EXISTS state(
+                    key TEXT PRIMARY KEY,
+                    value TEXT
+                );
+                CREATE TABLE IF NOT EXISTS pending_deltas(
+                    arena_id INTEGER NOT NULL,
+                    delta INTEGER NOT NULL,
+                    ts TEXT NOT NULL
+                );
+                """
+            )
+
+    # -- card operations --------------------------------------------------------
+
+    def replace_cards(self, cards: Dict[int, int]) -> None:
+        with self._lock, self._conn:
+            self._conn.execute("DELETE FROM cards")
+            self._conn.executemany(
+                "INSERT INTO cards(arena_id, quantity) VALUES(?, ?)",
+                [(int(aid), int(qty)) for aid, qty in cards.items()],
+            )
+
+    def apply_deltas(self, deltas: Dict[int, int]) -> None:
+        if not deltas:
+            return
+        with self._lock, self._conn:
+            for arena_id, delta in deltas.items():
+                self._conn.execute(
+                    """
+                    INSERT INTO cards(arena_id, quantity)
+                    VALUES(?, ?)
+                    ON CONFLICT(arena_id)
+                    DO UPDATE SET quantity = MAX(quantity + excluded.quantity, 0)
+                    """,
+                    (int(arena_id), int(delta)),
+                )
+
+    def set_card_quantity(self, arena_id: int, quantity: int) -> None:
+        with self._lock, self._conn:
+            self._conn.execute(
+                "INSERT INTO cards(arena_id, quantity) VALUES(?, ?)\n                 ON CONFLICT(arena_id) DO UPDATE SET quantity = excluded.quantity",
+                (int(arena_id), int(quantity)),
+            )
+
+    def get_all_cards(self) -> Dict[int, int]:
+        cur = self._conn.execute("SELECT arena_id, quantity FROM cards")
+        return {int(row["arena_id"]): int(row["quantity"]) for row in cur.fetchall()}
+
+    # -- metadata operations ----------------------------------------------------
+
+    def upsert_metadata(self, rows: Iterable[Tuple[int, str, str, str, str]]) -> None:
+        with self._lock, self._conn:
+            self._conn.executemany(
+                """
+                INSERT INTO metadata(arena_id, name, set_code, rarity, updated_at)
+                VALUES(?, ?, ?, ?, ?)
+                ON CONFLICT(arena_id) DO UPDATE SET
+                    name = excluded.name,
+                    set_code = excluded.set_code,
+                    rarity = excluded.rarity,
+                    updated_at = excluded.updated_at
+                """,
+                rows,
+            )
+
+    def get_metadata_map(self) -> Dict[int, Tuple[str, str, str]]:
+        cur = self._conn.execute("SELECT arena_id, name, set_code, rarity FROM metadata")
+        return {
+            int(row["arena_id"]): (
+                row["name"] or "",
+                row["set_code"] or "",
+                row["rarity"] or "",
+            )
+            for row in cur.fetchall()
+        }
+
+    # -- state ------------------------------------------------------------------
+
+    def get_state(self, key: str, default: Optional[str] = None) -> Optional[str]:
+        cur = self._conn.execute("SELECT value FROM state WHERE key = ?", (key,))
+        row = cur.fetchone()
+        return row["value"] if row else default
+
+    def set_state(self, key: str, value: str) -> None:
+        with self._lock, self._conn:
+            self._conn.execute(
+                "INSERT INTO state(key, value) VALUES(?, ?)\n                 ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+                (key, value),
+            )
+
+    # -- pending deltas ---------------------------------------------------------
+
+    def add_pending_delta(self, arena_id: int, delta: int, ts: str) -> None:
+        with self._lock, self._conn:
+            self._conn.execute(
+                "INSERT INTO pending_deltas(arena_id, delta, ts) VALUES(?, ?, ?)",
+                (int(arena_id), int(delta), ts),
+            )
+
+    def iter_pending_deltas(self) -> Iterator[PendingDelta]:
+        cur = self._conn.execute(
+            "SELECT arena_id, delta, ts FROM pending_deltas ORDER BY rowid"
+        )
+        for row in cur.fetchall():
+            yield PendingDelta(int(row["arena_id"]), int(row["delta"]), row["ts"])
+
+    def clear_pending_deltas(self) -> None:
+        with self._lock, self._conn:
+            self._conn.execute("DELETE FROM pending_deltas")
+
+    # -- helpers ----------------------------------------------------------------
+
+    def baseline_state(self) -> str:
+        return self.get_state("baseline", "missing") or "missing"
+
+    def mark_baseline_complete(self) -> None:
+        self.set_state("baseline", "complete")
+
+    def mark_baseline_missing(self) -> None:
+        self.set_state("baseline", "missing")
+
+
+__all__ = ["PendingDelta", "Store"]

--- a/src/tailer.py
+++ b/src/tailer.py
@@ -1,0 +1,60 @@
+"""Efficient polling based file tailer."""
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+from typing import Callable, Generator, Optional
+
+
+class FileTailer:
+    """Minimal polling tailer resilient to log rotation."""
+
+    def __init__(
+        self,
+        path: Path,
+        *,
+        active_interval: float = 0.5,
+        idle_interval: float = 5.0,
+        sleep: Optional[Callable[[float], None]] = None,
+    ) -> None:
+        self.path = Path(path)
+        self.active_interval = active_interval
+        self.idle_interval = idle_interval
+        self._sleep = sleep or time.sleep
+        self._offset = 0
+        self._inode: Optional[int] = None
+        self._last_size = 0
+
+    def follow(self, stop: Optional[Callable[[], bool]] = None) -> Generator[str, None, None]:
+        """Yield appended lines until ``stop`` returns True."""
+
+        while True:
+            if stop and stop():
+                return
+            try:
+                stat = self.path.stat()
+            except FileNotFoundError:
+                self._inode = None
+                self._offset = 0
+                self._sleep(self.idle_interval)
+                continue
+            inode = getattr(stat, "st_ino", None)
+            file_was_rotated = self._inode is not None and inode != self._inode
+            size_shrunk = stat.st_size < self._last_size
+            if file_was_rotated or size_shrunk:
+                self._offset = 0
+            self._inode = inode
+            self._last_size = stat.st_size
+            with self.path.open("r", encoding="utf-8", errors="ignore") as handle:
+                handle.seek(self._offset, os.SEEK_SET)
+                while True:
+                    line = handle.readline()
+                    if not line:
+                        self._offset = handle.tell()
+                        break
+                    yield line.rstrip("\n")
+            self._sleep(self.active_interval if stat.st_size > 0 else self.idle_interval)
+
+
+__all__ = ["FileTailer"]

--- a/src/tracker.py
+++ b/src/tracker.py
@@ -1,0 +1,239 @@
+"""Main application entrypoint for the MTGA collection tracker."""
+from __future__ import annotations
+
+import argparse
+import csv
+import datetime as _dt
+import sys
+import threading
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from .config import Config, load_config
+from .exporter import Exporter
+from .mapping import MappingManager
+from .parser import DeltaEvent, Parser, SnapshotEvent
+from .scheduler import Scheduler
+from .store import Store
+from .tailer import FileTailer
+from .version import __version__
+
+_PLAYER_LOG_RELATIVE = Path("Library/Logs/Wizards Of The Coast/MTGA/Unity/Player.log")
+_UTC = _dt.timezone.utc
+
+
+def _utcnow() -> _dt.datetime:
+    return _dt.datetime.now(tz=_UTC)
+
+
+class Tracker:
+    def __init__(self, config: Config, store: Store, mapping: MappingManager) -> None:
+        self.config = config
+        self.store = store
+        self.mapping = mapping
+        self.parser = Parser()
+        self.exporter = Exporter(config, store)
+        self.scheduler = Scheduler()
+        # Mapping refresh once a day by default.
+        self.scheduler.add_task("refresh-mapping", config.refresh_days * 86400, self.ensure_mapping)
+
+    # ------------------------------------------------------------------
+    # public API
+
+    def ensure_mapping(self) -> None:
+        if self.mapping.update_from_cache() == 0 and self.mapping.needs_refresh():
+            try:
+                self.mapping.refresh()
+            except Exception:
+                # Metadata refresh should not bring the daemon down; errors are logged by caller.
+                pass
+
+    def process_line(self, line: str) -> None:
+        for event in self.parser.parse_line(line):
+            if isinstance(event, SnapshotEvent):
+                self._handle_snapshot(event)
+            elif isinstance(event, DeltaEvent):
+                self._handle_delta(event)
+
+    def run(self, *, once: bool = False, stop_event: Optional[threading.Event] = None) -> None:
+        stop_event = stop_event or threading.Event()
+        log_path = self._player_log_path()
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        tailer = FileTailer(
+            log_path,
+            active_interval=self.config.active_interval,
+            idle_interval=self.config.idle_interval,
+        )
+        self.ensure_mapping()
+        if once:
+            self.exporter.export()
+            return
+        for line in tailer.follow(stop_event.is_set):
+            self.process_line(line)
+            self.scheduler.run_pending()
+
+    def export_now(self) -> int:
+        return self.exporter.export()
+
+    def seed_from_csv(self, csv_path: Path) -> int:
+        cards = self._read_seed_csv(csv_path)
+        self.store.replace_cards(cards)
+        self.store.mark_baseline_complete()
+        self._apply_pending_deltas()
+        return self.exporter.export()
+
+    def status(self) -> Dict[str, str]:
+        counts = len(self.store.get_all_cards())
+        baseline = self.store.baseline_state()
+        last_snapshot = self.store.get_state("last_snapshot", "")
+        return {
+            "cards": str(counts),
+            "baseline": baseline,
+            "last_snapshot": last_snapshot,
+        }
+
+    # ------------------------------------------------------------------
+    # internal helpers
+
+    def _handle_snapshot(self, event: SnapshotEvent) -> None:
+        self.store.replace_cards(event.cards)
+        self.store.mark_baseline_complete()
+        self.store.set_state("last_snapshot", _utcnow().isoformat())
+        self._apply_pending_deltas()
+        self.exporter.export()
+
+    def _handle_delta(self, event: DeltaEvent) -> None:
+        timestamp = event.raw.get("timestamp") if isinstance(event.raw, dict) else None
+        ts = timestamp or _utcnow().isoformat()
+        if self.store.baseline_state() != "complete":
+            for arena_id, delta in event.deltas.items():
+                self.store.add_pending_delta(arena_id, delta, ts)
+            return
+        self.store.apply_deltas(event.deltas)
+        self.exporter.export()
+
+    def _apply_pending_deltas(self) -> None:
+        pending = list(self.store.iter_pending_deltas())
+        if not pending:
+            return
+        aggregate: Dict[int, int] = {}
+        for item in pending:
+            aggregate[item.arena_id] = aggregate.get(item.arena_id, 0) + item.delta
+        self.store.apply_deltas(aggregate)
+        self.store.clear_pending_deltas()
+
+    def _player_log_path(self) -> Path:
+        return self.config.paths.base_dir / _PLAYER_LOG_RELATIVE
+
+    def _read_seed_csv(self, csv_path: Path) -> Dict[int, int]:
+        with csv_path.open("r", encoding="utf-8") as handle:
+            reader = csv.DictReader(handle)
+            id_field = None
+            qty_field = None
+            header_lower = {name.lower(): name for name in reader.fieldnames or []}
+            for key in ("arena_id", "grpid", "titleid", "id"):
+                if key in header_lower:
+                    id_field = header_lower[key]
+                    break
+            for key in ("quantity", "qty", "count"):
+                if key in header_lower:
+                    qty_field = header_lower[key]
+                    break
+            if not id_field or not qty_field:
+                raise ValueError("seed CSV must contain arena_id and quantity columns")
+            cards: Dict[int, int] = {}
+            for row in reader:
+                arena_id = int(row[id_field])
+                quantity = int(row[qty_field])
+                cards[arena_id] = quantity
+            return cards
+
+
+def create_tracker(base_dir: Optional[Path] = None) -> Tracker:
+    config = load_config(base_dir)
+    store = Store(config.paths.state_db)
+    mapping = MappingManager(config, store)
+    return Tracker(config=config, store=store, mapping=mapping)
+
+
+def _cmd_install(args: argparse.Namespace) -> int:
+    tracker = create_tracker()
+    tracker.ensure_mapping()
+    tracker.export_now()
+    print("Installation complete. Exports available at", tracker.config.paths.export_dir)
+    return 0
+
+
+def _cmd_uninstall(args: argparse.Namespace) -> int:
+    tracker = create_tracker()
+    # Leave existing exports and state in place to honour no-data-loss requirement.
+    tracker.store.close()
+    print("Uninstall does not remove data directories; delete manually if desired.")
+    return 0
+
+
+def _cmd_run(args: argparse.Namespace) -> int:
+    tracker = create_tracker()
+    once = getattr(args, "once", False)
+    tracker.run(once=once)
+    return 0
+
+
+def _cmd_seed(args: argparse.Namespace) -> int:
+    tracker = create_tracker()
+    tracker.seed_from_csv(Path(args.csv))
+    print("Seed import applied. Current status:", tracker.status())
+    return 0
+
+
+def _cmd_export(args: argparse.Namespace) -> int:
+    tracker = create_tracker()
+    tracker.export_now()
+    print("Export complete ->", tracker.config.paths.csv_export)
+    return 0
+
+
+def _cmd_status(args: argparse.Namespace) -> int:
+    tracker = create_tracker()
+    status = tracker.status()
+    for key, value in status.items():
+        print(f"{key}: {value}")
+    return 0
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="mtga-collection-tracker")
+    parser.add_argument("--version", action="version", version=f"%(prog)s {__version__}")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    install = sub.add_parser("install", help="install launchd agent")
+    install.set_defaults(func=_cmd_install)
+
+    uninstall = sub.add_parser("uninstall", help="remove launchd agent")
+    uninstall.set_defaults(func=_cmd_uninstall)
+
+    run = sub.add_parser("run", help="run the tracker in the foreground")
+    run.add_argument("--once", action="store_true", help="run initial export only")
+    run.set_defaults(func=_cmd_run)
+
+    seed = sub.add_parser("seed", help="import a baseline collection CSV")
+    seed.add_argument("csv", help="path to CSV file containing arena_id and quantity columns")
+    seed.set_defaults(func=_cmd_seed)
+
+    export = sub.add_parser("export", help="force a CSV/JSON export")
+    export.set_defaults(func=_cmd_export)
+
+    status = sub.add_parser("status", help="show tracker status")
+    status.set_defaults(func=_cmd_status)
+
+    return parser
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = build_arg_parser()
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    sys.exit(main())

--- a/src/version.py
+++ b/src/version.py
@@ -1,0 +1,5 @@
+"""Version information for mtga-collection-tracker."""
+
+__all__ = ["__version__"]
+
+__version__ = "0.1.0"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/fixtures/sample_inventory_deltas.log
+++ b/tests/fixtures/sample_inventory_deltas.log
@@ -1,0 +1,3 @@
+[2024-01-01T01:00:00Z] BoosterOpened {"payload":{"BoosterOpened":{"cards":[{"grpId":12345,"count":1},{"grpId":67890,"count":1}]}}}
+[2024-01-01T01:05:00Z] CraftCard {"payload":{"CraftCard":{"spentCards":[{"grpId":67890,"quantity":1}]}}}
+[2024-01-01T01:10:00Z] InventoryDelta {"payload":{"InventoryDelta":{"changes":[{"grpId":55555,"delta":2}]}}}

--- a/tests/fixtures/sample_player_snapshot.log
+++ b/tests/fixtures/sample_player_snapshot.log
@@ -1,0 +1,1 @@
+[2024-01-01T00:00:00Z] PlayerInventory {"Payload":{"Cards":[{"titleId":12345,"quantity":2},{"grpId":67890,"Quantity":4}]}}

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+
+from src.exporter import Exporter
+from src.tracker import create_tracker
+
+
+def test_exporter_writes_atomically(tmp_path: Path) -> None:
+    tracker = create_tracker(tmp_path)
+    tracker.store.replace_cards({111: 3})
+    tracker.store.mark_baseline_complete()
+    exporter = Exporter(tracker.config, tracker.store)
+    csv_path = tracker.config.paths.csv_export
+    csv_path.write_text("corrupted")
+    exporter.export()
+    assert csv_path.read_text().startswith("arena_id,quantity")
+    assert not csv_path.with_suffix(csv_path.suffix + ".tmp").exists()
+    json_path = tracker.config.paths.json_export
+    assert json_path.exists()

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -1,0 +1,21 @@
+import json
+from pathlib import Path
+
+from src.mapping import MappingManager
+from src.tracker import create_tracker
+
+
+def test_mapping_manager_prefers_non_promo(tmp_path: Path) -> None:
+    tracker = create_tracker(tmp_path)
+    mapping = MappingManager(tracker.config, tracker.store)
+    data = [
+        {"arena_id": 1, "name": "Promo", "set": "ppp", "rarity": "rare", "set_type": "promo", "released_at": "2020-01-01"},
+        {"arena_id": 1, "name": "Main", "set": "main", "rarity": "rare", "set_type": "expansion", "released_at": "2021-01-01"},
+        {"arena_id": 2, "name": "Other", "set": "oth", "rarity": "common", "set_type": "promo", "released_at": "2019-01-01"},
+    ]
+    tracker.config.paths.mapping_cache.write_text(json.dumps(data))
+    count = mapping.update_from_cache()
+    assert count == 2
+    metadata = tracker.store.get_metadata_map()
+    assert metadata[1] == ("Main", "main", "rare")
+    assert metadata[2] == ("Other", "oth", "common")

--- a/tests/test_parser_deltas.py
+++ b/tests/test_parser_deltas.py
@@ -1,0 +1,20 @@
+import csv
+from pathlib import Path
+
+from src.tracker import create_tracker
+
+
+def test_delta_sequence_updates_counts(tmp_path: Path) -> None:
+    tracker = create_tracker(tmp_path)
+    tracker.store.replace_cards({12345: 2, 67890: 1})
+    tracker.store.mark_baseline_complete()
+    fixture = Path(__file__).parent / "fixtures" / "sample_inventory_deltas.log"
+    for line in fixture.read_text().splitlines():
+        tracker.process_line(line)
+    cards = tracker.store.get_all_cards()
+    assert cards == {12345: 3, 67890: 1, 55555: 2}
+    csv_path = tracker.config.paths.csv_export
+    assert csv_path.exists()
+    with csv_path.open() as handle:
+        rows = list(csv.DictReader(handle))
+    assert any(row["arena_id"] == "55555" and row["quantity"] == "2" for row in rows)

--- a/tests/test_parser_snapshot.py
+++ b/tests/test_parser_snapshot.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+
+from src.parser import Parser, SnapshotEvent
+
+
+def test_snapshot_event_parsing(tmp_path: Path) -> None:
+    parser = Parser()
+    fixture = Path(__file__).parent / "fixtures" / "sample_player_snapshot.log"
+    events = []
+    for line in fixture.read_text().splitlines():
+        events.extend(parser.parse_line(line))
+    snapshots = [event for event in events if isinstance(event, SnapshotEvent)]
+    assert len(snapshots) == 1
+    snapshot = snapshots[0]
+    assert snapshot.cards == {12345: 2, 67890: 4}

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,0 +1,35 @@
+from typing import List
+
+from src.scheduler import Scheduler
+
+
+class _Clock:
+    def __init__(self) -> None:
+        self.now = 0.0
+
+    def advance(self, value: float) -> None:
+        self.now += value
+
+    def __call__(self) -> float:
+        return self.now
+
+
+def test_scheduler_respects_intervals() -> None:
+    clock = _Clock()
+    executed: List[str] = []
+
+    def task() -> None:
+        executed.append("run")
+
+    scheduler = Scheduler(time_fn=clock)
+    scheduler.add_task("demo", 5.0, task)
+    scheduler.run_pending()
+    assert executed == ["run"]
+    assert scheduler.time_until_next_task() == 5.0
+    clock.advance(2.0)
+    assert scheduler.time_until_next_task() == 3.0
+    scheduler.run_pending()
+    assert executed == ["run"]
+    clock.advance(3.1)
+    scheduler.run_pending()
+    assert executed == ["run", "run"]

--- a/tests/test_tailer.py
+++ b/tests/test_tailer.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+from src.tailer import FileTailer
+
+
+def test_tailer_handles_rotation(tmp_path: Path) -> None:
+    log_path = tmp_path / "Player.log"
+    log_path.write_text("")
+    tailer = FileTailer(log_path, active_interval=0.01, idle_interval=0.01, sleep=lambda _: None)
+    gen = tailer.follow(stop=lambda: False)
+
+    with log_path.open("a") as handle:
+        handle.write("first\n")
+    assert next(gen) == "first"
+
+    # Simulate rotation by renaming the file and creating a new one.
+    rotated = log_path.with_suffix(".1")
+    log_path.rename(rotated)
+    log_path.write_text("second\n")
+    assert next(gen) == "second"
+
+    gen.close()


### PR DESCRIPTION
## Summary
- add the Python tracker core with configuration, storage, parsing, mapping, exporting, and CLI wiring
- provide launchd template plus helper scripts for installing or uninstalling the macOS agent
- write pytest coverage for snapshot parsing, delta application, mapping, exporting, the tailer, and scheduler utilities

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68cf58e80a0083329a3edbe0f769198b