### PR TITLE
Fix macOS Player.log path detection

### DIFF
--- a/src/tracker.py
+++ b/src/tracker.py
@@ -26,7 +26,10 @@ from .store import Store
 from .tailer import FileTailer
 from .version import __version__
 
-_PLAYER_LOG_RELATIVE = Path("Library/Logs/Wizards Of The Coast/MTGA/Unity/Player.log")
+_PLAYER_LOG_RELATIVE_CANDIDATES = (
+    Path("Library/Logs/Wizards Of The Coast/MTGA/Player.log"),
+    Path("Library/Logs/Wizards Of The Coast/MTGA/Unity/Player.log"),
+)
 _UTC = _dt.timezone.utc
 
 
@@ -131,7 +134,14 @@ class Tracker:
         self.store.clear_pending_deltas()
 
     def _player_log_path(self) -> Path:
-        return self.config.paths.base_dir / _PLAYER_LOG_RELATIVE
+        base = self.config.paths.base_dir
+        for relative in _PLAYER_LOG_RELATIVE_CANDIDATES:
+            candidate = base / relative
+            if candidate.exists():
+                return candidate
+        # Fall back to the first known location so we at least create the
+        # directory structure for a fresh installation.
+        return base / _PLAYER_LOG_RELATIVE_CANDIDATES[0]
 
     def _read_seed_csv(self, csv_path: Path) -> Dict[int, int]:
         with csv_path.open("r", encoding="utf-8") as handle:

--- a/tests/test_tracker_paths.py
+++ b/tests/test_tracker_paths.py
@@ -1,0 +1,36 @@
+from src.tracker import create_tracker
+
+
+def test_player_log_path_prefers_existing_primary(tmp_path):
+    tracker = create_tracker(base_dir=tmp_path)
+    try:
+        log_dir = tmp_path / "Library/Logs/Wizards Of The Coast/MTGA"
+        log_dir.mkdir(parents=True, exist_ok=True)
+        expected = log_dir / "Player.log"
+        expected.write_text("test")
+
+        assert tracker._player_log_path() == expected
+    finally:
+        tracker.store.close()
+
+
+def test_player_log_path_uses_unity_variant_when_present(tmp_path):
+    tracker = create_tracker(base_dir=tmp_path)
+    try:
+        unity_dir = tmp_path / "Library/Logs/Wizards Of The Coast/MTGA/Unity"
+        unity_dir.mkdir(parents=True, exist_ok=True)
+        expected = unity_dir / "Player.log"
+        expected.write_text("test")
+
+        assert tracker._player_log_path() == expected
+    finally:
+        tracker.store.close()
+
+
+def test_player_log_path_defaults_to_primary_location(tmp_path):
+    tracker = create_tracker(base_dir=tmp_path)
+    try:
+        expected = tmp_path / "Library/Logs/Wizards Of The Coast/MTGA/Player.log"
+        assert tracker._player_log_path() == expected
+    finally:
+        tracker.store.close()


### PR DESCRIPTION
## Summary
- detect the MTGA Player.log at the top-level macOS path before the Unity subdirectory
- fall back to the Unity variant when present and keep a default for fresh installs
- add regression tests covering the player log path selection logic

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cfe5d645808332b1a155c4121e2fb6